### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/phantomstudios/next-basic-auth/security/code-scanning/5](https://github.com/phantomstudios/next-basic-auth/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow to define minimal permissions for all jobs. Since the workflow involves testing and publishing to npm, we will grant `contents: read` for accessing the repository's contents and `packages: write` for publishing to npm. This ensures that the workflow has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
